### PR TITLE
Highlight usage of a list in Going Deep

### DIFF
--- a/3.md
+++ b/3.md
@@ -76,6 +76,7 @@ Here's something a little more involved you may enjoy: a preview of message-pass
 
 * ``receive`` accepts in-coming messages; it is often used with pattern-matching in to dispatch
 * Tuples can be expressed as literals ``#(...)`` or by calling a constructor ``(tuple ...)``; below we use the literal form (with ``backquote`` and ``unquote``) in the ``receive`` pattern
+* Lists can be expressed as literals `` `(...)`` or by calling a constructor ``(list ...)``; below we use both the literal form (with ``backquote``) and the `list` constructor form in the ``io:format`` calls
 * The ``!`` functions is the "send" function -- we use it here to send a message to the process identified by the given LFE process ID 
 * The ``spawn`` function calls a function as a separate process and returns the ID for the new process; this ID can then be used to send messages to the process itself (and that process can use ``receive`` to handle in-coming messages)
 
@@ -87,7 +88,7 @@ Here's something a little more involved you may enjoy: a preview of message-pass
 (defun print-result ()
   (receive
     (`#(,pid ,msg)
-      (io:format "Received message: '~s'~n" (list msg))
+      (io:format "Received message: '~s'~n" `(msg))
       (io:format "Sending message to process ~p ...~n" (list pid))
       (! pid `#(,msg))
       (print-result))))


### PR DESCRIPTION
The Going Deep section was using different forms of Tuples in the `messenger-back` example, and it was using `list` just by using the list constructor.

This fix added the overview of the list literal and list constructor to the quick hints, and made use of the list literal in the example.
